### PR TITLE
Feature/mqtt client

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,22 +1,7 @@
 from services import mqtt_client
-import time
-
-def handle_test_message(payload):
-  print(f"[TEST] Callback triggered with payload: {payload}")
 
 def main():
-  print("[TEST] Starting MQTT client...")
-  mqtt_client.subscribe("test/topic", handle_test_message)
-  mqtt_client.start()
-
-  time.sleep(2)
-  mqtt_client.publish("test/topic", {
-    "message": "Hello from test",
-    "timestamp": "2025-04-30T12:34:56"
-  })
-
-  time.sleep(5)
-  print("[TEST] Done.")
+  mqtt_client.run_mqtt_test()
 
 if __name__ == "__main__":
   main()

--- a/main.py
+++ b/main.py
@@ -1,12 +1,22 @@
-from fastapi import FastAPI
+from services import mqtt_client
+import time
 
-app = FastAPI()
+def handle_test_message(payload):
+  print(f"[TEST] Callback triggered with payload: {payload}")
 
-@app.get("/")
-def read_root():
-    return {"message": "Locker API running on Raspberry PI"}
+def main():
+  print("[TEST] Starting MQTT client...")
+  mqtt_client.subscribe("test/topic", handle_test_message)
+  mqtt_client.start()
 
-@app.post("/unlock")
-def unlock_locket(locker_id: int):
-    return {"status": "unlocked", "locker_id": locker_id}
+  time.sleep(2)
+  mqtt_client.publish("test/topic", {
+    "message": "Hello from test",
+    "timestamp": "2025-04-30T12:34:56"
+  })
 
+  time.sleep(5)
+  print("[TEST] Done.")
+
+if __name__ == "__main__":
+  main()

--- a/services/config.py
+++ b/services/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
   MQTT_BROKER: str

--- a/services/config.py
+++ b/services/config.py
@@ -1,0 +1,11 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+  MQTT_BROKER: str
+  MQTT_PORT: int
+  MQTT_KEEPALIVE: int = 60
+
+  class Config:
+    env_file = ".env"
+  
+settings = Settings()

--- a/services/mqtt_client.py
+++ b/services/mqtt_client.py
@@ -1,5 +1,6 @@
 import paho.mqtt.client as mqtt
 import threading
+import json
 
 from services.config import settings
 
@@ -7,21 +8,49 @@ MQTT_BROKER = settings.MQTT_BROKER
 MQTT_PORT = settings.MQTT_PORT
 MQTT_KEEPALIVE = settings.MQTT_KEEPALIVE
 
-client = mqtt.Client()
+mqtt_client = mqtt.Client()
 
 callback_registry = {}
 
 def on_connect(client, userdata, flags, rc):
-  pass
+  print(f"[MQTT] Connected with result code {rc}")
+  for topic in callback_registry:
+    client.subscribe(topic)
 
 def on_message(client, userdata, msg):
-  pass
+  topic = msg.topic
+  payload_raw = msg.payload.decode("utf-8")
+  
+  try:
+    payload = json.loads(payload_raw)
+  except json.JSONDecodeError:
+    print(f"[MQTT] Invalid JSON format on {topic}: {payload_raw}")
+    return
+  
+  print(f"[MQTT] Message received on {topic}: {payload}")
 
-def publish(topic: str, message: str):
-  pass
+  if topic in callback_registry:
+    callback_registry[topic](payload)
+
+def publish(topic: str, message: dict):
+  try:
+    json_message = json.dumps(message)
+    print(f"[MQTT] Publishing to {topic}: {json_message}")
+    mqtt_client.publish(topic, json_message)
+  except Exception as e:
+    print(f"[MQTT] Failed to publish to {topic}: {e}")
 
 def subscribe(topic: str, callback):
-  pass
+  print(f"[MQTT] Subscribing to {topic}")
+  callback_registry[topic] = callback
+  mqtt_client.subscribe(topic)
 
 def start():
-  pass
+  mqtt_client.on_connect = on_connect
+  mqtt_client.on_message = on_message
+
+  mqtt_client.connect(MQTT_BROKER, MQTT_PORT, MQTT_KEEPALIVE)
+
+  thread = threading.Thread(target=mqtt_client.loop_forever, daemon=True)
+  thread.start()
+  print(f"[MQTT] Loop started in background")

--- a/services/mqtt_client.py
+++ b/services/mqtt_client.py
@@ -1,0 +1,27 @@
+import paho.mqtt.client as mqtt
+import threading
+
+from services.config import settings
+
+MQTT_BROKER = settings.MQTT_BROKER
+MQTT_PORT = settings.MQTT_PORT
+MQTT_KEEPALIVE = settings.MQTT_KEEPALIVE
+
+client = mqtt.Client()
+
+callback_registry = {}
+
+def on_connect(client, userdata, flags, rc):
+  pass
+
+def on_message(client, userdata, msg):
+  pass
+
+def publish(topic: str, message: str):
+  pass
+
+def subscribe(topic: str, callback):
+  pass
+
+def start():
+  pass

--- a/services/mqtt_client.py
+++ b/services/mqtt_client.py
@@ -1,6 +1,7 @@
 import paho.mqtt.client as mqtt
 import threading
 import json
+import time
 
 from services.config import settings
 
@@ -54,3 +55,20 @@ def start():
   thread = threading.Thread(target=mqtt_client.loop_forever, daemon=True)
   thread.start()
   print(f"[MQTT] Loop started in background")
+
+def run_mqtt_test():
+    def handle_test_message(payload):
+        print(f"[TEST] Callback triggered with payload: {payload}")
+
+    print("[TEST] Starting MQTT client...")
+    subscribe("test/topic", handle_test_message)
+    start()
+
+    time.sleep(2)
+    publish("test/topic", {
+        "message": "Hello from test",
+        "timestamp": "2025-04-30T12:34:56"
+    })
+
+    time.sleep(5)
+    print("[TEST] Done.")


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요(이미지 첨부 가능, how보다는 what, why)

MQTT 관련 로직을 처리하는 mqtt_client를 완성헀습니다.

.env로부터, mqtt 브로커의 주소와 포트, keepalive 시간을 받아온 후, 이를 paho.mqtt.client를 이용해서 client를 구성합니다.

이때, 각 topic에 대한 메시지가 왔을 때에 사전에 정의된 callback함수를 실행하여, 데이터를 받아서 보내도록 합니다.(코드 상에선 `callback_registry`에 저장)

이후 subscribe, publish를 원하면 함수를 통해 구독/발행을 처리해줍니다.

그리고 추가로 코드가 잘 작동하는지 테스트를 해보기 위해 간단한 테스트 코드도 작성해봤습니다.