### PR TITLE
Feature/verify

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,7 @@
-from fastapi import FastAPI
+from services import mqtt_client
 
-app = FastAPI()
+def main():
+  mqtt_client.run_mqtt_test()
 
-@app.get("/")
-def read_root():
-    return {"message": "Locker API running on Raspberry PI"}
-
-@app.post("/unlock")
-def unlock_locket(locker_id: int):
-    return {"status": "unlocked", "locker_id": locker_id}
-
+if __name__ == "__main__":
+  main()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,19 @@
-from services import mqtt_client
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from routers import verify
 
-def main():
-  mqtt_client.run_mqtt_test()
+app = FastAPI()
 
-if __name__ == "__main__":
-  main()
+app.add_middleware(
+  CORSMiddleware,
+  allow_origins=["*"],
+  allow_credentials=True,
+  allow_methods=["*"],
+  allow_headers=["*"],
+)
+
+app.include_router(verify.router, prefix="/api")
+
+@app.get("/")
+def root():
+  return {"message": "RENTit Pi Backend API is running"}

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routers import verify
 
+from services.logic import start_subscribers
+
 app = FastAPI()
 
 app.add_middleware(
@@ -17,3 +19,5 @@ app.include_router(verify.router, prefix="/api")
 @app.get("/")
 def root():
   return {"message": "RENTit Pi Backend API is running"}
+
+start_subscribers()

--- a/main.py
+++ b/main.py
@@ -1,23 +1,30 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import verify
 
+from routers import verify
 from services.logic import start_subscribers
 
-app = FastAPI()
 
-app.add_middleware(
-  CORSMiddleware,
-  allow_origins=["*"],
-  allow_credentials=True,
-  allow_methods=["*"],
-  allow_headers=["*"],
-)
+def create_app() -> FastAPI:
+    app = FastAPI()
 
-app.include_router(verify.router, prefix="/api")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
-@app.get("/")
-def root():
-  return {"message": "RENTit Pi Backend API is running"}
+    app.include_router(verify.router, prefix="/api")
+
+    @app.get("/")
+    def root():
+        return {"message": "RENTit Pi Backend API is running"}
+
+    return app
+
+
+app = create_app()
 
 start_subscribers()

--- a/mock.py
+++ b/mock.py
@@ -1,0 +1,33 @@
+from services import mqtt_client
+import time
+
+def handle_verification_request(payload):
+    otp = payload.get("otp")
+    if not otp:
+        print("[MOCK] Invalid verification payload (missing OTP)")
+        return
+
+    print(f"[MOCK] Received OTP verification request for: {otp}")
+
+    # 응답 메시지 구성
+    response = {
+        "otp": otp,
+        "valid": True,
+        "user_id": "mock_user_001",
+        "user_name": "테스트사용자",
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+    }
+
+    mqtt_client.publish("event/ajou/locker1/otp_result", response)
+    print(f"[MOCK] Sent mock OTP result for {otp}")
+
+def main():
+    print("[MOCK] Starting MQTT client and subscribing to otp_verification...")
+    mqtt_client.subscribe("event/ajou/locker1/otp_verification", handle_verification_request)
+    mqtt_client.start()
+
+    while True:
+        time.sleep(1)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ h11==0.16.0
 idna==3.10
 paho-mqtt==2.1.0
 pydantic==2.11.3
+pydantic-settings==2.9.1
 pydantic_core==2.33.1
 setuptools==78.1.0
 sniffio==1.3.1

--- a/routers/verify.py
+++ b/routers/verify.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from services import otp_service
+from services.cache import get_otp_result
 
 router = APIRouter()
 
@@ -17,8 +18,8 @@ def verify_otp(request: OTPRequest):
     return {"message": "OTP verification request sent"}
 
 @router.get("/verify/result")
-def get_result(otp: str = Query(..., description="OTP to check result for")): # need query parameter. ex) GET /api/verify/result?otp=1234
-    result = otp_service.get_otp_result(otp)
+def get_result(otp: str = Query(..., description="OTP to check result for")):
+    result = get_otp_result(otp)
     if result is None:
         return {"verified": None}
     return result

--- a/routers/verify.py
+++ b/routers/verify.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+from services import otp_service
+
+router = APIRouter()
+
+class OTPRequest(BaseModel):
+    otp: str
+    action: str
+
+@router.post("/verify")
+def verify_otp(request: OTPRequest):
+    if not request.otp or not request.action:
+        raise HTTPException(status_code=400, detail="Missing otp or action")
+
+    otp_service.send_otp_verification(request.otp, request.action)
+    return {"message": "OTP verification request sent"}
+
+@router.get("/verify/result")
+def get_result(otp: str = Query(..., description="OTP to check result for")): # need query parameter. ex) GET /api/verify/result?otp=1234
+    result = otp_service.get_otp_result(otp)
+    if result is None:
+        return {"verified": None}
+    return result

--- a/routers/verify.py
+++ b/routers/verify.py
@@ -1,25 +1,26 @@
-from fastapi import APIRouter, HTTPException, Query
+# routers/verify.py
+
+from fastapi import APIRouter, Query
 from pydantic import BaseModel
+
 from services import otp_service
 from services.cache import get_otp_result
 
 router = APIRouter()
 
+
 class OTPRequest(BaseModel):
     otp: str
     action: str
 
-@router.post("/verify")
-def verify_otp(request: OTPRequest):
-    if not request.otp or not request.action:
-        raise HTTPException(status_code=400, detail="Missing otp or action")
 
+@router.post("/verify")
+def verify_otp(request: OTPRequest) -> dict:
     otp_service.send_otp_verification(request.otp, request.action)
     return {"message": "OTP verification request sent"}
 
+
 @router.get("/verify/result")
-def get_result(otp: str = Query(..., description="OTP to check result for")):
+def get_result(otp: str = Query(..., description="OTP to check result for")) -> dict:
     result = get_otp_result(otp)
-    if result is None:
-        return {"verified": None}
-    return result
+    return result if result is not None else {"verified": None}

--- a/services/cache.py
+++ b/services/cache.py
@@ -1,6 +1,6 @@
 otp_cache = {}
 
-def cache_otp_result(otp: str, response: dict):
+def cache_otp_result(otp, response):
     otp_cache[otp] = {
         "verified": response.get("valid"),
         "response": response

--- a/services/cache.py
+++ b/services/cache.py
@@ -1,12 +1,12 @@
-otp_cache = {}
+otp_cache: dict[str, dict] = {}
 
-def cache_otp_result(otp, response):
+def cache_otp_result(otp: str, response: dict) -> None:
     otp_cache[otp] = {
         "verified": response.get("valid"),
         "response": response
     }
 
-def get_otp_result(otp):
+def get_otp_result(otp: str) -> dict | None:
     entry = otp_cache.get(otp)
     if entry and entry["verified"] is not None:
         return entry["response"]

--- a/services/cache.py
+++ b/services/cache.py
@@ -1,0 +1,13 @@
+otp_cache = {}
+
+def cache_otp_result(otp: str, response: dict):
+    otp_cache[otp] = {
+        "verified": response.get("valid"),
+        "response": response
+    }
+
+def get_otp_result(otp):
+    entry = otp_cache.get(otp)
+    if entry and entry["verified"] is not None:
+        return entry["response"]
+    return None

--- a/services/config.py
+++ b/services/config.py
@@ -1,13 +1,14 @@
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
-  MQTT_BROKER: str
-  MQTT_PORT: int
-  MQTT_KEEPALIVE: int = 60
-  UNIVERSITY_ID: str
-  LOCKER_ID: str
+    MQTT_BROKER: str
+    MQTT_PORT: int
+    MQTT_KEEPALIVE: int = 60
+    UNIVERSITY_ID: str
+    LOCKER_ID: str
 
-  class Config:
-    env_file = "../.env"
-  
+    model_config = {
+        "env_file": "../.env"
+    }
+
 settings = Settings()

--- a/services/config.py
+++ b/services/config.py
@@ -1,0 +1,11 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+  MQTT_BROKER: str
+  MQTT_PORT: int
+  MQTT_KEEPALIVE: int = 60
+
+  class Config:
+    env_file = ".env"
+  
+settings = Settings()

--- a/services/config.py
+++ b/services/config.py
@@ -4,8 +4,10 @@ class Settings(BaseSettings):
   MQTT_BROKER: str
   MQTT_PORT: int
   MQTT_KEEPALIVE: int = 60
+  UNIVERSITY_ID: str
+  LOCKER_ID: str
 
   class Config:
-    env_file = ".env"
+    env_file = "../.env"
   
 settings = Settings()

--- a/services/logic.py
+++ b/services/logic.py
@@ -1,4 +1,3 @@
-# services/logic.py
 from services import mqtt_client
 from services.cache import cache_otp_result
 from services.config import settings
@@ -6,15 +5,16 @@ from services.config import settings
 university_id = settings.UNIVERSITY_ID
 locker_id = settings.LOCKER_ID
 
-def handle_otp_result(payload: dict):
+def handle_otp_result(payload: dict) -> None:
     otp = payload.get("otp")
     if not otp:
         print("[LOGIC] Invalid OTP result payload")
         return
+
     cache_otp_result(otp, payload)
     print(f"[LOGIC] OTP result cached: {otp} → {payload}")
 
-def start_subscribers():
+def start_subscribers() -> None:
     topic = f"event/{university_id}/{locker_id}/otp_result"
     mqtt_client.start()
     mqtt_client.subscribe(topic, handle_otp_result)

--- a/services/logic.py
+++ b/services/logic.py
@@ -1,0 +1,21 @@
+# services/logic.py
+from services import mqtt_client
+from services.cache import cache_otp_result
+from services.config import settings
+
+university_id = settings.UNIVERSITY_ID
+locker_id = settings.LOCKER_ID
+
+def handle_otp_result(payload: dict):
+    otp = payload.get("otp")
+    if not otp:
+        print("[LOGIC] Invalid OTP result payload")
+        return
+    cache_otp_result(otp, payload)
+    print(f"[LOGIC] OTP result cached: {otp} → {payload}")
+
+def start_subscribers():
+    topic = f"event/{university_id}/{locker_id}/otp_result"
+    mqtt_client.start()
+    mqtt_client.subscribe(topic, handle_otp_result)
+    print(f"[LOGIC] Subscribed to: {topic}")

--- a/services/mqtt_client.py
+++ b/services/mqtt_client.py
@@ -9,48 +9,52 @@ MQTT_PORT = settings.MQTT_PORT
 MQTT_KEEPALIVE = settings.MQTT_KEEPALIVE
 
 mqtt_client = mqtt.Client()
-
 callback_registry = {}
 
-def on_connect(client, userdata, flags, rc):
-  print(f"[MQTT] Connected with result code {rc}")
-  for topic in callback_registry:
-    client.subscribe(topic)
 
-def on_message(client, userdata, msg):
-  topic = msg.topic
-  payload_raw = msg.payload.decode("utf-8")
-  
-  try:
-    payload = json.loads(payload_raw)
-  except json.JSONDecodeError:
-    print(f"[MQTT] Invalid JSON format on {topic}: {payload_raw}")
-    return
-  
-  print(f"[MQTT] Message received on {topic}: {payload}")
+def on_connect(client, userdata, flags, rc) -> None:
+    print(f"[MQTT] Connected with result code {rc}")
+    for topic in callback_registry:
+        client.subscribe(topic)
 
-  if topic in callback_registry:
-    callback_registry[topic](payload)
 
-def publish(topic: str, message: dict):
-  try:
-    json_message = json.dumps(message)
-    print(f"[MQTT] Publishing to {topic}: {json_message}")
-    mqtt_client.publish(topic, json_message)
-  except Exception as e:
-    print(f"[MQTT] Failed to publish to {topic}: {e}")
+def on_message(client, userdata, msg) -> None:
+    topic = msg.topic
+    raw = msg.payload.decode("utf-8")
 
-def subscribe(topic: str, callback):
-  print(f"[MQTT] Subscribing to {topic}")
-  callback_registry[topic] = callback
-  mqtt_client.subscribe(topic)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        print(f"[MQTT] Invalid JSON on {topic}: {raw}")
+        return
 
-def start():
-  mqtt_client.on_connect = on_connect
-  mqtt_client.on_message = on_message
+    print(f"[MQTT] Message received on {topic}: {payload}")
 
-  mqtt_client.connect(MQTT_BROKER, MQTT_PORT, MQTT_KEEPALIVE)
+    if topic in callback_registry:
+        callback_registry[topic](payload)
 
-  thread = threading.Thread(target=mqtt_client.loop_forever, daemon=True)
-  thread.start()
-  print(f"[MQTT] Loop started in background")
+
+def publish(topic: str, message: dict) -> None:
+    try:
+        json_message = json.dumps(message)
+        print(f"[MQTT] Publishing to {topic}: {json_message}")
+        mqtt_client.publish(topic, json_message)
+    except Exception as e:
+        print(f"[MQTT] Failed to publish to {topic}: {e}")
+
+
+def subscribe(topic: str, callback) -> None:
+    print(f"[MQTT] Subscribing to {topic}")
+    callback_registry[topic] = callback
+    mqtt_client.subscribe(topic)
+
+
+def start() -> None:
+    mqtt_client.on_connect = on_connect
+    mqtt_client.on_message = on_message
+
+    mqtt_client.connect(MQTT_BROKER, MQTT_PORT, MQTT_KEEPALIVE)
+
+    thread = threading.Thread(target=mqtt_client.loop_forever, daemon=True)
+    thread.start()
+    print("[MQTT] Loop started in background")

--- a/services/mqtt_client.py
+++ b/services/mqtt_client.py
@@ -1,0 +1,74 @@
+import paho.mqtt.client as mqtt
+import threading
+import json
+import time
+
+from services.config import settings
+
+MQTT_BROKER = settings.MQTT_BROKER
+MQTT_PORT = settings.MQTT_PORT
+MQTT_KEEPALIVE = settings.MQTT_KEEPALIVE
+
+mqtt_client = mqtt.Client()
+
+callback_registry = {}
+
+def on_connect(client, userdata, flags, rc):
+  print(f"[MQTT] Connected with result code {rc}")
+  for topic in callback_registry:
+    client.subscribe(topic)
+
+def on_message(client, userdata, msg):
+  topic = msg.topic
+  payload_raw = msg.payload.decode("utf-8")
+  
+  try:
+    payload = json.loads(payload_raw)
+  except json.JSONDecodeError:
+    print(f"[MQTT] Invalid JSON format on {topic}: {payload_raw}")
+    return
+  
+  print(f"[MQTT] Message received on {topic}: {payload}")
+
+  if topic in callback_registry:
+    callback_registry[topic](payload)
+
+def publish(topic: str, message: dict):
+  try:
+    json_message = json.dumps(message)
+    print(f"[MQTT] Publishing to {topic}: {json_message}")
+    mqtt_client.publish(topic, json_message)
+  except Exception as e:
+    print(f"[MQTT] Failed to publish to {topic}: {e}")
+
+def subscribe(topic: str, callback):
+  print(f"[MQTT] Subscribing to {topic}")
+  callback_registry[topic] = callback
+  mqtt_client.subscribe(topic)
+
+def start():
+  mqtt_client.on_connect = on_connect
+  mqtt_client.on_message = on_message
+
+  mqtt_client.connect(MQTT_BROKER, MQTT_PORT, MQTT_KEEPALIVE)
+
+  thread = threading.Thread(target=mqtt_client.loop_forever, daemon=True)
+  thread.start()
+  print(f"[MQTT] Loop started in background")
+
+def run_mqtt_test():
+    def handle_test_message(payload):
+        print(f"[TEST] Callback triggered with payload: {payload}")
+
+    print("[TEST] Starting MQTT client...")
+    subscribe("test/topic", handle_test_message)
+    start()
+
+    time.sleep(2)
+    publish("test/topic", {
+        "message": "Hello from test",
+        "timestamp": "2025-04-30T12:34:56"
+    })
+
+    time.sleep(5)
+    print("[TEST] Done.")

--- a/services/mqtt_client.py
+++ b/services/mqtt_client.py
@@ -1,7 +1,6 @@
 import paho.mqtt.client as mqtt
 import threading
 import json
-import time
 
 from services.config import settings
 
@@ -55,20 +54,3 @@ def start():
   thread = threading.Thread(target=mqtt_client.loop_forever, daemon=True)
   thread.start()
   print(f"[MQTT] Loop started in background")
-
-def run_mqtt_test():
-    def handle_test_message(payload):
-        print(f"[TEST] Callback triggered with payload: {payload}")
-
-    print("[TEST] Starting MQTT client...")
-    subscribe("test/topic", handle_test_message)
-    start()
-
-    time.sleep(2)
-    publish("test/topic", {
-        "message": "Hello from test",
-        "timestamp": "2025-04-30T12:34:56"
-    })
-
-    time.sleep(5)
-    print("[TEST] Done.")

--- a/services/otp_service.py
+++ b/services/otp_service.py
@@ -1,12 +1,12 @@
-# services/otp_service.py
+import time
 from services import mqtt_client
 from services.config import settings
-import time
 
 university_id = settings.UNIVERSITY_ID
 locker_id = settings.LOCKER_ID
 
-def send_otp_verification(otp: str, action: str):
+
+def send_otp_verification(otp: str, action: str) -> None:
     topic = f"event/{university_id}/{locker_id}/otp_verification"
     payload = {
         "otp": otp,
@@ -15,4 +15,4 @@ def send_otp_verification(otp: str, action: str):
     }
 
     mqtt_client.publish(topic, payload)
-    print(f"[OTP_SERVICE] Published verification request: {payload}")
+    print(f"[OTP_SERVICE] Sent OTP verification: {payload}")

--- a/services/otp_service.py
+++ b/services/otp_service.py
@@ -1,3 +1,4 @@
+# services/otp_service.py
 from services import mqtt_client
 from services.config import settings
 import time
@@ -5,11 +6,6 @@ import time
 university_id = settings.UNIVERSITY_ID
 locker_id = settings.LOCKER_ID
 
-# Simple data cache for storing OTP verification status
-# key: otp, value: {verified, user_id, ...}
-otp_cache = {}
-
-# publish mqtt message, which topic is otp_verification
 def send_otp_verification(otp: str, action: str):
     topic = f"event/{university_id}/{locker_id}/otp_verification"
     payload = {
@@ -18,33 +14,5 @@ def send_otp_verification(otp: str, action: str):
         "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
     }
 
-    otp_cache[otp] = {"verified": None, "response": None}
-
     mqtt_client.publish(topic, payload)
-
-# callback function for subscription
-def handle_otp_result(payload):
-    otp = payload.get("otp")
-    if not otp:
-        print("[OTP] Invalid payload: missing otp")
-        return
-
-    if otp in otp_cache:
-        otp_cache[otp]["verified"] = payload.get("valid", False)
-        otp_cache[otp]["response"] = payload
-        print(f"[OTP] Cached result for OTP {otp}: {payload}")
-    else:
-        print(f"[OTP] Received result for unknown OTP: {otp}")
-
-# deal with frontend's polling check
-def get_otp_result(otp: str):
-    entry = otp_cache.get(otp)
-    if entry and entry["verified"] is not None:
-        return entry["response"]
-    return None
-
-# create subscription for otp result
-def subscribe_to_otp_result():
-    topic = f"event/{university_id}/{locker_id}/otp_result"
-    mqtt_client.subscribe(topic, handle_otp_result)
-    print(f"[OTP] Subscribed to {topic}")
+    print(f"[OTP_SERVICE] Published verification request: {payload}")

--- a/services/otp_service.py
+++ b/services/otp_service.py
@@ -1,0 +1,50 @@
+from services import mqtt_client
+from services.config import settings
+import time
+
+university_id = settings.UNIVERSITY_ID
+locker_id = settings.LOCKER_ID
+
+# Simple data cache for storing OTP verification status
+# key: otp, value: {verified, user_id, ...}
+otp_cache = {}
+
+# publish mqtt message, which topic is otp_verification
+def send_otp_verification(otp: str, action: str):
+    topic = f"event/{university_id}/{locker_id}/otp_verification"
+    payload = {
+        "otp": otp,
+        "action": action,
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+    }
+
+    otp_cache[otp] = {"verified": None, "response": None}
+
+    mqtt_client.publish(topic, payload)
+
+# callback function for subscription
+def handle_otp_result(payload):
+    otp = payload.get("otp")
+    if not otp:
+        print("[OTP] Invalid payload: missing otp")
+        return
+
+    if otp in otp_cache:
+        otp_cache[otp]["verified"] = payload.get("valid", False)
+        otp_cache[otp]["response"] = payload
+        print(f"[OTP] Cached result for OTP {otp}: {payload}")
+    else:
+        print(f"[OTP] Received result for unknown OTP: {otp}")
+
+# deal with frontend's polling check
+def get_otp_result(otp: str):
+    entry = otp_cache.get(otp)
+    if entry and entry["verified"] is not None:
+        return entry["response"]
+    return None
+
+# create subscription for otp result
+def subscribe_to_otp_result():
+    topic = f"event/{university_id}/{locker_id}/otp_result"
+    mqtt_client.subscribe(topic, handle_otp_result)
+    print(f"[OTP] Subscribed to {topic}")

--- a/test/test_mqtt_client.py
+++ b/test/test_mqtt_client.py
@@ -1,0 +1,26 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from services import mqtt_client
+import time
+
+def handle_test_message(payload):
+    print(f"[TEST] Callback triggered with payload: {payload}")
+
+def main():
+    print("[TEST] Starting MQTT client...")
+    mqtt_client.subscribe("test/topic", handle_test_message)
+    mqtt_client.start()
+
+    time.sleep(2)
+    mqtt_client.publish("test/topic", {
+        "message": "Hello from test",
+        "timestamp": "2025-04-30T12:34:56"
+    })
+
+    time.sleep(5)
+    print("[TEST] Done.")
+
+if __name__ == "__main__":
+    main()

--- a/test/test_otp_service.py
+++ b/test/test_otp_service.py
@@ -1,0 +1,32 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from services import mqtt_client
+from services import otp_service
+import time
+
+def main():
+    test_otp = "12345"
+    test_action = "store"
+
+    print("[TEST] Subscribing to OTP result topic...")
+    otp_service.subscribe_to_otp_result()
+    mqtt_client.start()
+
+    time.sleep(1)
+    print(f"[TEST] Sending OTP verification: {test_otp}, action: {test_action}")
+    otp_service.send_otp_verification(test_otp, test_action)
+
+    print("[TEST] Waiting for OTP result...")
+    for _ in range(10):
+        result = otp_service.get_otp_result(test_otp)
+        if result:
+            print(f"[TEST] OTP result received: {result}")
+            break
+        time.sleep(1)
+    else:
+        print("[TEST] Timeout: No OTP result received")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📝작업 내용

OTP와 관련된 백엔드 로직을 구성 완료했습니다.

간단히 설명하면,
`verify.py`: otp관련 API엔드포인트 정의
`cache.py`: 기타 런타임에서 필요한 상태들을 임시저장하는 장소. 여기에선 otp요청과 결과를 저장하는 공간(나중에 요청 만료 등의 메커니즘을 추가해야하긴 하겠군요...)
`mqtt_client.py`: 저번에 만든 mqtt관련 함수 정의. pub/sub 모두 여기에서 이루어집니다.
`otp_service.py`: `mqtt_client`에게 otp관련 메시지를 발급하도록 하는 함수입니다(밑의 `logic`에 다 몰아주면 너무 한 코드에만 의존성이 몰린다고 생각해서 나눴습니다)
`logic.py`: 앞으로 백엔드 서버의 핵심 로직들이 들어갈 장소입니다. 일단은 otp_result의 콜백 함수와, 이를 구독과 연결시켜두는 것만 들어가 있어요.
`main.py`: 실제 백엔드 서버의 시작점입니다.
`mock.py`: otp인증을 로컬의 mqtt로 보내는 테스트용입니다. 실제 서버에서는 다른 보안 요소를 집어넣어서 mock가 동작 못하게 해야겠죠...??

이번에 구현된 API는 아래와 같습니다:
`POST /verify`: 프론트에서 사용자가 입력한 OTP값을 서버로 보냅니다. 그러면 서버는 이를 받아서 otp_verification 메시지를 pub해요.
`GET /verify/result?otp={otp_num}`: 프론트가 OTP값의 인증 결과를 polling으로 가져옵니다. 서버는 otp_result로 온 메시지를 sub하고 있다가, 메시지를 가져와서 인증 결과를 cache에 들고있다가, 이를 보내줘요.

그리고 지금까지 작성된 모든 코드들에 대해서 리펙토링도 진행했습니다.

## 스크린샷 (변경된 화면이 있다면 첨부)
![image](https://github.com/user-attachments/assets/2130d2db-40f3-406f-94b8-a4621a3381d6)
